### PR TITLE
capitalize none colors

### DIFF
--- a/colors/github.vim
+++ b/colors/github.vim
@@ -59,8 +59,8 @@ hi PreProc guifg=#f47067
 " ale
 hi ALEErrorSign guibg=#22272e guifg=#f47067
 hi ALEWarningSign guibg=#22272e guifg=#daaa3f
-hi ALEError guibg=none guifg=none
-hi ALEWarning guibg=none guifg=none
+hi ALEError guibg=NONE guifg=NONE
+hi ALEWarning guibg=NONE guifg=NONE
 
 " coc.nvim
 hi CocErrorSign guibg=#22272e guifg=#f47067


### PR DESCRIPTION
Fixes:

```
line   62:
E254: Cannot allocate color none
E254: Cannot allocate color none
line   63:
E254: Cannot allocate color none
E254: Cannot allocate color none
```

```
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Mar 30 2022 20:12:27)
macOS version - arm64
Included patches: 1-4650
```